### PR TITLE
feat: unify todo write flow and improve meeting context recovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@
 *.tmp
 *.bak
 config/local.*.yaml
+
+# Local mirrors / external skill repos not part of this skill
+external-skills/
+
+# Session/process planning artifacts (not product assets)
+task_plan.md
+findings.md
+progress.md

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,6 +140,19 @@ flowchart TD
 - 档案
 - Todo
 
+它可以决定：
+
+- 是否应该建议写回
+- 具体触达哪些对象
+- 为每个对象产出什么 `write candidate`
+
+但它不应直接负责：
+
+- live schema 校验
+- dedupe 执行
+- 真实写入调用
+- 写入结果结构化返回
+
 ## 4. 飞书工作台底座
 
 这是当前架构最关键的一层。
@@ -260,6 +273,13 @@ flowchart LR
 
 只在用户确认后执行。
 
+当前收口原则是：
+
+- 场景层负责产出 `change plan` 和 `write candidate`
+- 底座负责统一执行 writer
+- writer 统一返回 `write result`
+- 不允许每个场景各自拼写入细节
+
 写回顺序保持不变：
 
 1. Base tables
@@ -269,8 +289,28 @@ flowchart LR
 原则：
 
 - 写前必须经过 live schema preflight
+- 写前必须经过 write guard 与对象级 dedupe
 - 任何 unsafe 情况都停在 recommendation mode
 - 不为了“写成功”而发明 fallback 值
+
+当前第一批统一写回对象：
+
+1. Todo
+
+统一写回协议当前最小包含：
+
+- `WriteCandidate`
+  - `target_object`
+  - `operation`
+  - `match_basis`
+  - `source_context`
+- `WriteExecutionResult`
+  - `preflight_status`
+  - `guard_status`
+  - `dedupe_decision`
+  - `executed_operation`
+  - `blocked_reasons`
+  - `remote_object_id`
 
 ---
 
@@ -292,10 +332,11 @@ sequenceDiagram
     G-->>S: hydrated context
 
     S->>S: 做会议解读、提炼信号、形成建议
-    S->>G: 写前 preflight
-    G->>F: 检查 live schema / options
-    F-->>G: safe / drift / blocked
-    G-->>S: preflight report
+    S->>S: 产出 change plan + write candidate
+    S->>G: 确认后调用统一 writer
+    G->>F: 检查 live schema / options / dedupe / write
+    F-->>G: write result
+    G-->>S: preflight + guard + dedupe + write result
 
     S-->>U: 分析 + 建议更新 + blocked/drift
 ```
@@ -303,8 +344,8 @@ sequenceDiagram
 这条链路强调：
 
 - 会议场景不直接访问飞书细节
-- 飞书访问和写前校验由底座统一处理
-- 上层场景只处理经营解释和输出
+- 飞书访问、写前校验和真实写入由底座统一处理
+- 上层场景只处理经营解释、候选生成和输出
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@
 
 ## [Unreleased]
 
+### 新增
+
+- `runtime/models.py`
+  - 为统一落盘通道补充 `WriteCandidate` 公共字段：`operation`、`match_basis`、`source_context`、`target_object`
+  - 新增 `WriteExecutionResult` 统一写回结果模型
+- `evals/meeting_output_bridge.py`
+  - 新增最小 Todo candidate 生成与 confirmed write 调用入口
+  - 输出中可展示统一写回结果摘要
+
+### 变更
+
+- `runtime/todo_writer.py`
+  - 从 Todo 专用返回结构收口到统一写回结果语义
+  - 增加第一版 minimal semantic dedupe，支持 `create_new` / `update_existing` / `create_subtask` / `no_write` 决策
+  - duplicate 命中后默认走 `update_existing` 自动 patch
+  - `create_subtask` 默认 recommendation-only，显式确认（`confirm_create_subtask=true`）后执行真实子任务创建
+- `evals/meeting_output_bridge.py`
+  - 增加“相关会议纪要候选”命中与排序最小层（基于客户联系记录标题/日期/链接）
+- `tests/test_runtime_smoke.py`、`tests/test_meeting_output_bridge.py`
+  - 新增 dedupe 中文变体、create_subtask 可选执行、meeting-note 候选排序回归用例
+- `ARCHITECTURE.md`、`references/feishu-workbench-gateway.md`、`references/task-patterns.md`
+  - 明确“场景层产出 write candidate，底座统一执行 writer”的分层边界
+- `STATUS.md`、`VALIDATION.md`
+  - 新增 unified Todo writer 的状态和验证口径
+
 ## [0.2.11] - 2026-04-11
 
 ### 新增

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ python3 -m unittest tests.test_runtime_smoke tests.test_meeting_output_bridge te
 
 - 同一核心任务优先“更新已有任务（update_existing）”
 - 若是更细执行步骤，优先“建议拆分子任务（create_subtask）”
-- 子任务默认是建议态，显式确认后才会执行创建
+- 子任务默认是建议态，显式确认（source_context.confirm_create_subtask=true）后才会执行创建
 
 ## 路线图（抽象）
 

--- a/README.md
+++ b/README.md
@@ -1,131 +1,149 @@
 # feishu-am-workbench
 
-一个面向个人 AM 场景的 Codex Skill，用于围绕飞书“经营工作平台”完成客户分析、会议准备、会后沉淀、经营判断和确认后回写。
+Feishu AM Workbench 是一个面向客户经营（AM）工作的飞书技能。
 
-这个仓库用于版本化管理 `feishu-am-workbench`，让 skill 的规则、字段映射、路由逻辑、兼容性策略和模板演进都能通过 GitHub 持续治理。
+它不是单纯的“会议总结器”，而是一套帮助 AM 把日常工作做稳、做深、做成闭环的工作方法：
 
-当前阶段的主线不是“先做成通用产品”，而是优先把这套 skill 打磨成对你个人高频 AM 工作真正有用的能力层；配置抽离和通用化继续保留，但排在后面。
+- 先恢复上下文，再给判断
+- 先出建议，再确认写回
+- 先做校验，再触发变更
 
-## 这个 skill 做什么
+目标是把 AM 的日常动作从“零散信息处理”，升级成“可追踪、可复盘、可持续优化”的经营闭环。
 
-- 分析多种 AM 输入：
-  - 本地客户资料目录
-  - 会议纪要
-  - 你的自然语言补充
-  - 飞书 Base 中的经营工作台数据
-  - 客户档案文档
-  - 客户公开资讯
-- 产出：
-  - 客户经营分析和判断
-  - 对飞书经营工作台的更新建议
-  - 在你确认后的 Base / 文档 / Todo 回写
-- 严格执行经营规则：
-  - 每个客户只能有 1 份正式客户档案
-  - 日期必须使用绝对时间
-  - 客户主数据表是快照层，不是流水账
-  - 长会议纪要进入“冷记忆”文档，不直接塞进 Base
-  - Todo 必须有责任人，且要做语义去重
-  - 写回前先做 live schema 检查，避免字段或选项漂移导致误写
+## 产品定位
 
-## 仓库结构
+这个技能的核心价值，不是“多写一份总结”，而是帮助 AM 把每天最耗精力的工作变得更稳、更快、更可持续。
 
-- [SKILL.md](./SKILL.md)
-  - skill 主说明，定义工作流、写回边界和硬约束
-- [ARCHITECTURE.md](./ARCHITECTURE.md)
-  - 当前架构分层、gateway 位置和 runtime 边界
-- [agents/openai.yaml](./agents/openai.yaml)
-  - agent 展示信息和默认 prompt
-- [references/](./references)
-  - 规则说明、字段快照、路由规则、兼容性策略等参考文件
-- [CHANGELOG.md](./CHANGELOG.md)
-  - skill 的版本变更记录
-- [VERSION](./VERSION)
-  - 当前 skill 版本
-- [config/](./config)
-  - workspace config 模板和脱敏示例，用来承接 live schema 兼容落地
-- [ROADMAP.md](./ROADMAP.md)
-  - skill 的中长期演进路线图
-- [CONFIG-MODEL.md](./CONFIG-MODEL.md)
-  - 通用 skill 与个人私有飞书环境之间的配置分层设计
-- [SECURITY-MODEL.md](./SECURITY-MODEL.md)
-  - skill 公开或给其他人使用时的安全设计
-- [VALIDATION.md](./VALIDATION.md)
-  - 当前版本的真实场景回归检查清单
-- [STATUS.md](./STATUS.md)
-  - 当前实现进度、阻点和下一步，避免部分完成状态丢失
-- [WORKFLOW.md](./WORKFLOW.md)
-  - 开发分支迭代和合并节奏说明
-- [runtime/](./runtime)
-  - skill 内部底座执行层，包含 gateway、resolver、hydrator、preflight、write guard 的本地模块
-  - 当前已支持通过 `lark-cli` 产出 live capability report，并返回 resource catalog / query guide，告诉上层有哪些资源可查、优先用什么工具查
-- [references/meeting-context-recovery.md](./references/meeting-context-recovery.md)
-  - 会议纪要场景下的上下文恢复流程
-- [references/meeting-type-classification.md](./references/meeting-type-classification.md)
-  - 会议类型分类和不同类型对应的写回上限
-- [references/meeting-note-doc-standard.md](./references/meeting-note-doc-standard.md)
-  - 结构化会议纪要文档标准、保真边界和 AI 提示语
-- [references/meeting-output-standard.md](./references/meeting-output-standard.md)
-  - 会议纪要最终输出结构、中文标题规范和动态建议态更新规则
-- [references/feishu-runtime-sources.md](./references/feishu-runtime-sources.md)
-  - 当前个人环境下飞书资源线索从哪里取
-- [references/live-resource-links.md](./references/live-resource-links.md)
-  - 当前个人环境的真实飞书入口 URL，供 runtime 直接解析 Base / folder / tasklist 入口
-- [references/feishu-workbench-gateway.md](./references/feishu-workbench-gateway.md)
-  - skill 内部统一的飞书工作台访问底座
-- [references/base-integration-model.md](./references/base-integration-model.md)
-  - 多维表格接入模型：只维护最小语义面，不做全字段镜像
-- [references/minimal-stable-core.md](./references/minimal-stable-core.md)
-  - 定义哪些是后续优化时不应轻易改动的最小稳定内核
-- [.github/](./.github)
-  - GitHub issue / PR 模板
+它重点辅助 AM 做好四类日常工作：
 
-## 当前设计原则
+1. 会前准备：快速恢复客户上下文，知道这次会要解决什么，不再临时拼信息。
+2. 会后沉淀：把会议结论、待确认问题、后续动作拆清楚，减少“开完会就断线”。
+3. 客户经营跟进：把分散在聊天、纪要、表格里的信号串成连续线程，避免遗漏关键动作。
+4. 团队协同执行：把待办责任人、优先级和重复任务管住，让推进动作真正落地。
 
-这套 skill 不假设飞书经营工作台的 schema 永远不变。
+对应的业务结果是：
 
-它采用的是：
+- 降低上下文切换成本，提升每次沟通的准备质量。
+- 减少遗漏、误写和重复任务，提升执行确定性。
+- 让客户经营从“靠记忆”变成“可追踪、可复盘、可优化”的工作流。
 
-- skill 内固化稳定的业务规则
-- config 内定义每个 workspace 的资源映射、语义字段位和枚举治理
-- reference 文件保存当前 schema 快照和字段意图
-- 真正写回前，实时读取 live schema 和 live options
-- 写回前按照 live schema preflight contract 输出可审计的 drift / block 结果
-- 字段改名时，优先 live 匹配，其次才是 alias fallback
-- 一旦无法安全匹配，就停留在建议态，不做盲写
-- 优先保持 minimal stable core 稳定，把 runtime 细节放在扩展层演进
-- 当前已补一层本地 `runtime/` 骨架，用来承接飞书工作台底座的执行层
-- 当前多维表格接入已引入 `table profile` 模型：
-  - profile 可以先纳入表级角色和约束
-  - semantic slots 只在场景真正需要时再补
+它背后的运行原则可以概括为三句：
 
-## 本地安装方式
+- 先恢复上下文，再做判断。
+- 先给执行建议，再确认落盘。
+- 先保证写入安全，再追求自动化。
 
-当前真源目录就是：
+## 核心能力
+
+### 1. 会前会后助手
+
+- 支持会议纪要、逐字稿、会后整理输入
+- 先恢复客户背景，不把单份纪要当成全部事实
+- 输出中明确区分：事实、判断、开放问题、写回边界
+
+### 2. 客户经营资产管理
+
+- 将客户概况与过程记录分层管理
+- 长文本沉淀在文档，表格保持结构化字段
+- 在需要时关联客户档案和历史线程，避免脱离背景的结论
+
+### 3. 统一 Todo 闭环
+
+- 支持创建、更新、暂不写入、建议拆分子任务等决策
+- 支持语义去重，减少重复任务与并行冲突
+
+## 运行原则
+
+### 上下文优先
+
+- 会议类任务先恢复最小必要背景，再做结论
+- 输出明确标注依据来源，方便复核和追踪
+
+### 写入前防护
+
+- 写入前先检查字段与选项是否匹配当前环境
+- 写入前检查负责人与关键约束是否满足
+- 不满足安全条件时保持建议模式
+
+### 漂移兼容
+
+- 优先使用当前环境中的真实字段与选项
+- 同义词只用于辅助匹配，不作为盲写依据
+- 兼容失败时宁可阻断写入，也不做不可解释变更
+
+## 快速开始
+
+### 前置条件
+
+1. 已安装并可用 lark-cli
+2. 已完成飞书认证并具备目标资源访问权限
+3. 本地 Python 3.10+
+
+### 1) 先跑环境诊断
 
 ```bash
-~/.codex/skills/feishu-am-workbench
+python3 -m runtime .
 ```
 
-## 迭代方式
+如果三个核心能力都显示为 `available`，就可以进入真实验证。
 
-建议所有有意义的 skill 变更都走 GitHub 管理，包括：
+### 2) 再跑会议场景验证
 
-- Base 字段映射调整
-- 经营规则变化
-- 客户档案模板规则变化
-- 写回路由和去重规则变化
-- Todo 结构和字段使用变化
-- schema 兼容策略变化
+```bash
+python3 -m evals.meeting_output_bridge \
+  --eval-name unilever-stage-review \
+  --transcript-file tests/fixtures/transcripts/20260410-联合利华\ Campaign活动分析优化-阶段汇报.txt \
+  --run-gateway \
+  --customer-query 联合利华
+```
 
-小范围字段快照刷新可以直接提交，但涉及经营逻辑和写回边界的变化，建议通过 PR 审核后再合并。
+重点观察：资源解析状态、客户解析结果、上下文恢复状态、已使用资料。
 
-## 建议的 issue 类型
+### 3) 运行验证集
 
-- `Skill change`
-  - 用于提行为、模板、路由、规则、写回策略调整
-- `Schema drift`
-  - 用于提飞书 Base 字段改名、增删字段、选项变化、任务清单自定义字段变化
+```bash
+python3 -m unittest tests.test_runtime_smoke tests.test_meeting_output_bridge tests.test_eval_runner tests.test_validation_assets
+```
 
-## 当前状态
+## 写回策略
 
-这个仓库已经是 `feishu-am-workbench` 的唯一真源，且本地 Codex 直接从这个目录加载。
+### 默认行为
+
+- 先建议，后确认
+- 未确认不写入
+- 责任人未解析时不创建待办
+
+### 去重行为
+
+- 同一核心任务优先“更新已有任务（update_existing）”
+- 若是更细执行步骤，优先“建议拆分子任务（create_subtask）”
+- 子任务默认是建议态，显式确认后才会执行创建
+
+## 路线图（抽象）
+
+### M1 稳态执行内核
+
+持续压实写回稳定性、回归样本和失败模式治理，降低误写/漏写/重复写风险。
+
+### M2 经营闭环增强
+
+从“完成落盘”升级到“主动提炼经营信号”，形成客户周报、风险提醒和动作缺口提示。
+
+### M3 复杂输入深度解读
+
+提升会议纪要与历史资料的分阶段解读能力，强化事实-判断-行动的专家级链路。
+
+### M4 兼容性与通用化
+
+增强跨工作区（workspace）的字段适配能力，降低硬编码依赖，沉淀可迁移的经营方法模型（operating model）。
+
+## 项目资源导航
+
+- 核心规则与入口: [SKILL.md](SKILL.md)
+- 架构边界: [ARCHITECTURE.md](ARCHITECTURE.md)
+- 当前状态: [STATUS.md](STATUS.md)
+- 验证协议: [VALIDATION.md](VALIDATION.md)
+- 变更记录: [CHANGELOG.md](CHANGELOG.md)
+- 演进路线: [ROADMAP.md](ROADMAP.md)
+- 运行时执行层: [runtime/](runtime)
+- 规则与策略文档: [references/](references)

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,7 +15,7 @@
 
 ## 当前结论
 
-当前仓库已经进入“底座可执行、meeting 场景最小 `live-first` 闭环已验证完成、后续以 roadmap 增强为主”的阶段。
+当前仓库已经进入“底座可执行、meeting 场景最小 `live-first` 闭环已验证完成、Todo 已收口为第一批统一写回对象、后续继续按 roadmap 增强”的阶段。
 
 - Base: 已可 live 读取
 - Todo: 已可 live 读取
@@ -135,6 +135,39 @@
 - 更多 drift case 回归样本
 - Todo custom field 仍主要依赖当前已验证快照，不是从任务设置接口直接发现
 
+### 5.1 Unified Todo Write Surface
+
+状态：`已完成第一版收口`
+
+已完成：
+
+- `WriteCandidate` 已补最小公共写回字段：
+  - `operation`
+  - `match_basis`
+  - `source_context`
+  - `target_object`
+- `WriteExecutionResult` 已作为统一写回结果模型落地
+- `TodoWriteResult` 已对齐统一结果结构
+- `TodoWriter` 已统一返回：
+  - preflight 状态
+  - guard 状态
+  - dedupe 决策
+  - executed operation
+  - blocked reasons
+  - remote object id / url
+- Todo 已补最小 semantic dedupe 第一版
+- `evals/meeting_output_bridge.py` 已能：
+  - 生成最小 Todo candidate
+  - 在确认后调用统一 Todo writer
+  - 在输出中展示统一写回结果
+
+当前限制：
+
+- 当前 dedupe 仍是最小规则，只覆盖 customer + summary + time window 的近重复判断
+- duplicate 命中后默认走 `update_existing` 自动 patch
+- step-level duplicate 会优先返回 `create_subtask` 建议；仅当 `source_context.confirm_create_subtask=true` 时执行真实子任务创建
+- meeting 入口当前只接了最小 Todo candidate 生成，不代表所有场景都已迁移
+
 ### 6. Base Integration Model
 
 状态：`已落到 runtime 第一版`
@@ -201,10 +234,10 @@ python3 -m runtime .
 
 1. 收尾当前分支文档和状态口径，确认只剩 roadmap 级增强项
 2. 补更强的 meeting-note 命中和排序策略
-3. 继续收口 live schema 的 Todo / write guard 相关真实联调验证
+3. 继续收口 unified Todo writer 的真实联调验证和 dedupe 规则
 4. 把 Base 读取从“大批量读取后本地筛选”继续改成“精准查询优先”
 5. 把 archive doc 正文读取、历史 meeting-note docs 定向读取、ontology 建模留到 roadmap 后续阶段
 
 ## 更新时间
 
-- 2026-04-11
+- 2026-04-12

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -9,6 +9,10 @@
 
 当前协议不是重型 benchmark 框架，而是可重复执行的最小闭环。
 
+本轮新增一条验证主线：
+
+- 统一 Todo 写回通道是否已经形成最小闭环
+
 ## 验证目标
 
 本轮验证的目标不是证明“自动写回 ready”，而是证明：
@@ -18,6 +22,7 @@
 - recommendation mode / no-write 边界更稳
 - 关键 hard rules 对真实场景有实际约束力
 - 会议分析前会先尝试 live-first gateway，而不是默认单文件分析
+- meeting 场景产出的 Todo candidate 已可进入统一 writer，并返回标准化 write result
 
 ## 样本范围
 
@@ -120,6 +125,17 @@
 - 是否避免盲猜字段名
 - 是否把输出重心放在该场景真正需要的内容上
 
+如果场景涉及 Todo，还要额外检查：
+
+- 是否产出结构化 Todo candidate
+- candidate 是否带 `operation`、`match_basis`、`source_context`、`target_object`
+- 是否显示 dedupe 决策
+- 是否显示 preflight / guard / blocked 结果
+- recommendation mode 和 confirmed write mode 是否分离清楚
+- 若命中 `create_subtask`：
+   - 默认是否保持 recommendation-only
+   - 仅在显式确认（`source_context.confirm_create_subtask=true`）时才执行真实写入
+
 ## 当前执行方式
 
 本轮默认使用三层验证资产：
@@ -130,10 +146,11 @@
 2. 数据层
    - `evals/evals.json` 保存真实案例、预期行为和断言
 3. 执行层
-   - `evals/runner.py` 读取案例和 agent 输出，并逐条执行断言
-   - `evals/meeting_output_bridge.py` 把 transcript + gateway 结果拼成 runner 可复核的最小输出
-   - bridge 既支持手工注入 `GatewayResult`，也支持先执行 gateway 再生成输出
-   - bridge 现在可继续执行最小 Stage 3 context recovery：读取 `客户联系记录`、`行动计划` 和客户档案链接
+  - `evals/runner.py` 读取案例和 agent 输出，并逐条执行断言
+  - `evals/meeting_output_bridge.py` 把 transcript + gateway 结果拼成 runner 可复核的最小输出
+  - bridge 既支持手工注入 `GatewayResult`，也支持先执行 gateway 再生成输出
+  - bridge 现在可继续执行最小 Stage 3 context recovery：读取 `客户联系记录`、`行动计划` 和客户档案链接
+  - bridge 现在可生成最小 Todo candidate，并在确认后调用统一 Todo writer
 
 ## 当前验证报告
 
@@ -152,3 +169,4 @@
 - `CHANGELOG.md`、`VERSION`、`evals/evals.json` 版本一致
 - 统一验证报告已经产出
 - 可以给出按 P1 / P3 排序的修改建议
+- 至少 1 个 meeting 场景已验证统一 Todo writer 的 candidate -> result 闭环

--- a/evals/meeting_output_bridge.py
+++ b/evals/meeting_output_bridge.py
@@ -2,13 +2,21 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+import re
 from typing import Protocol
 
 from runtime.gateway import FeishuWorkbenchGateway
 from runtime.lark_cli import LarkCliClient
 from runtime.live_adapter import LarkCliBaseQueryBackend, LiveWorkbenchConfig
 from runtime.runtime_sources import RuntimeSourceLoader
-from runtime.models import CustomerMatch, CustomerResolution, GatewayResult, ResourceResolution
+from runtime.models import (
+    CustomerMatch,
+    CustomerResolution,
+    GatewayResult,
+    ResourceResolution,
+    WriteCandidate,
+    WriteExecutionResult,
+)
 
 
 class GatewayRunner(Protocol):
@@ -23,6 +31,11 @@ class QueryBackend(Protocol):
         ...
 
 
+class TodoWriteExecutor(Protocol):
+    def create(self, candidate: WriteCandidate) -> WriteExecutionResult:
+        ...
+
+
 def build_meeting_output(
     *,
     eval_name: str,
@@ -33,6 +46,7 @@ def build_meeting_output(
     fallback_reason: str | None = None,
     key_context: list[str] | None = None,
     missing_sources: list[str] | None = None,
+    write_results: list[WriteExecutionResult] | None = None,
 ) -> str:
     transcript_title = transcript_path.name
     transcript_text, transcript_status = _read_transcript_text(transcript_path)
@@ -56,6 +70,9 @@ def build_meeting_output(
         lines.extend(f"- {item}" for item in key_context)
     if missing_sources:
         lines.append(f"未找到但应存在的资料: {'、'.join(missing_sources)}")
+    if write_results:
+        lines.append("统一写回结果:")
+        lines.extend(_render_write_results(write_results))
 
     lines.extend(_render_case_body(eval_name, transcript_text))
     return "\n".join(lines)
@@ -80,6 +97,7 @@ def run_gateway_and_build_meeting_output(
     context = recover_live_context(
         gateway_result=gateway_result,
         query_backend=query_backend,
+        topic_text=transcript_path.stem,
     )
     output_text = build_meeting_output(
         eval_name=eval_name,
@@ -92,6 +110,56 @@ def run_gateway_and_build_meeting_output(
         missing_sources=context["missing_sources"],
     )
     return output_text, gateway_result
+
+
+def build_meeting_todo_candidates(
+    *,
+    eval_name: str,
+    gateway_result: GatewayResult,
+) -> list[WriteCandidate]:
+    resolution = gateway_result.customer_resolution
+    if resolution is None or resolution.status != "resolved" or not resolution.candidates:
+        return []
+    customer = resolution.candidates[0]
+    if eval_name != "unilever-stage-review":
+        return []
+    summary = _build_recommended_todo_summary(eval_name, customer.short_name)
+    return [
+        WriteCandidate(
+            object_name="待办",
+            target_object="todo",
+            layer="reminder",
+            operation="create",
+            semantic_fields=["summary", "owner", "customer", "priority", "due_at"],
+            payload={
+                "summary": summary,
+                "customer": customer.short_name,
+                "priority": "高",
+                "description": "来自会议场景的建议态跟进动作；负责人待确认后才能真正写入。",
+            },
+            match_basis={
+                "customer": customer.short_name,
+            },
+            source_context={
+                "scenario": "post_meeting",
+                "meeting_eval": eval_name,
+                "customer_id": customer.customer_id,
+            },
+        )
+    ]
+
+
+def run_confirmed_todo_write(
+    *,
+    candidates: list[WriteCandidate],
+    todo_writer: TodoWriteExecutor,
+) -> list[WriteExecutionResult]:
+    results: list[WriteExecutionResult] = []
+    for candidate in candidates:
+        if candidate.operation == "update":
+            continue
+        results.append(todo_writer.create(candidate))
+    return results
 
 
 def _render_customer_resolution(gateway_result: GatewayResult) -> str:
@@ -112,6 +180,7 @@ def recover_live_context(
     *,
     gateway_result: GatewayResult,
     query_backend: QueryBackend,
+    topic_text: str = "",
 ) -> dict[str, object]:
     resolution = gateway_result.customer_resolution
     if resolution is None:
@@ -151,6 +220,11 @@ def recover_live_context(
     else:
         missing_sources.append("行动计划")
 
+    meeting_notes = _rank_related_meeting_notes(contact_rows, topic_text=topic_text, limit=3)
+    if meeting_notes:
+        used_sources.append("相关会议纪要候选")
+        key_context.append(f"相关会议纪要候选: {'；'.join(meeting_notes)}")
+
     if best.archive_link:
         used_sources.append("客户档案链接")
         key_context.append(f"客户档案链接: {best.archive_link}")
@@ -186,6 +260,58 @@ def _render_latest_action(row: dict[str, object]) -> str:
     return f"当前行动计划: {action}｜{due_at}"
 
 
+def _rank_related_meeting_notes(
+    contact_rows: list[dict[str, object]],
+    *,
+    topic_text: str,
+    limit: int,
+) -> list[str]:
+    if not contact_rows:
+        return []
+    topic_terms = _topic_terms(topic_text)
+    candidates: list[tuple[int, str]] = []
+    seen_links: set[str] = set()
+    for row in contact_rows:
+        title = str(
+            row.get("会议纪要标题")
+            or row.get("记录标题")
+            or row.get("主题")
+            or ""
+        ).strip()
+        link = str(
+            row.get("会议纪要链接")
+            or row.get("会议记录链接")
+            or row.get("纪要链接")
+            or ""
+        ).strip()
+        date = str(row.get("联系日期") or row.get("记录时间") or "")
+        if not title or not link or link in seen_links:
+            continue
+        seen_links.add(link)
+        score = _meeting_note_score(title=title, date=date, topic_terms=topic_terms)
+        candidates.append((score, f"{title}｜{date or '日期未提供'}｜{link}"))
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return [item[1] for item in candidates[:limit]]
+
+
+def _topic_terms(text: str) -> set[str]:
+    normalized = text.lower()
+    normalized = re.sub(r"[^a-z0-9\u4e00-\u9fff]+", " ", normalized)
+    parts = [part for part in normalized.split() if part]
+    stop_words = {"会议", "纪要", "记录", "阶段", "汇报"}
+    return {part for part in parts if part not in stop_words}
+
+
+def _meeting_note_score(*, title: str, date: str, topic_terms: set[str]) -> int:
+    title_terms = _topic_terms(title)
+    overlap = len(title_terms.intersection(topic_terms)) if topic_terms else 0
+    score = overlap * 10
+    if date:
+        score += 3
+    return score
+
+
 def _render_case_body(eval_name: str, transcript_text: str) -> list[str]:
     if eval_name == "unilever-stage-review":
         return _render_unilever_body(transcript_text)
@@ -194,6 +320,24 @@ def _render_case_body(eval_name: str, transcript_text: str) -> list[str]:
     if eval_name == "dominos-ad-tracking-qa":
         return _render_dominos_body(transcript_text)
     raise KeyError(f"unsupported eval case: {eval_name}")
+
+
+def _render_write_results(write_results: list[WriteExecutionResult]) -> list[str]:
+    lines: list[str] = []
+    for item in write_results:
+        blocked = ",".join(item.blocked_reasons) if item.blocked_reasons else "none"
+        lines.append(
+            f"- {item.target_object}: {item.executed_operation} "
+            f"(dedupe={item.dedupe_decision}; preflight={item.preflight_status}; "
+            f"guard={item.guard_status}; blocked={blocked})"
+        )
+    return lines
+
+
+def _build_recommended_todo_summary(eval_name: str, customer_name: str) -> str:
+    if eval_name == "unilever-stage-review":
+        return f"跟进{customer_name}下一轮 Campaign 优化方案确认"
+    return f"跟进{customer_name}会议后续动作确认"
 
 
 def _render_unilever_body(transcript_text: str) -> list[str]:

--- a/evals/meeting_output_bridge.py
+++ b/evals/meeting_output_bridge.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+from datetime import datetime
 from pathlib import Path
 import re
 from typing import Protocol
@@ -309,7 +310,26 @@ def _meeting_note_score(*, title: str, date: str, topic_terms: set[str]) -> int:
     score = overlap * 10
     if date:
         score += 3
+        note_dt = _parse_note_date(date)
+        if note_dt is not None:
+            days = abs((datetime.utcnow() - note_dt).days)
+            if days <= 30:
+                score += 20
+            elif days <= 90:
+                score += 10
     return score
+
+
+def _parse_note_date(date_str: str) -> datetime | None:
+    # Extract first YYYY-MM-DD-like token from mixed date strings.
+    match = re.search(r"(\d{4})-(\d{1,2})-(\d{1,2})", date_str)
+    if not match:
+        return None
+    try:
+        year, month, day = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        return datetime(year, month, day)
+    except ValueError:
+        return None
 
 
 def _render_case_body(eval_name: str, transcript_text: str) -> list[str]:

--- a/evals/meeting_output_bridge.py
+++ b/evals/meeting_output_bridge.py
@@ -140,6 +140,7 @@ def build_meeting_todo_candidates(
             },
             match_basis={
                 "customer": customer.short_name,
+                "time_window": "2026-04",
             },
             source_context={
                 "scenario": "post_meeting",
@@ -158,6 +159,19 @@ def run_confirmed_todo_write(
     results: list[WriteExecutionResult] = []
     for candidate in candidates:
         if candidate.operation == "update":
+            results.append(
+                WriteExecutionResult(
+                    target_object=candidate.target_object,
+                    attempted=False,
+                    allowed=False,
+                    preflight_status="safe",
+                    guard_status="blocked",
+                    dedupe_decision="no_write",
+                    executed_operation="blocked",
+                    blocked_reasons=["update_operation_not_supported_in_confirmed_write"],
+                    source_context=dict(candidate.source_context),
+                )
+            )
             continue
         results.append(todo_writer.create(candidate))
     return results
@@ -270,7 +284,7 @@ def _rank_related_meeting_notes(
     if not contact_rows:
         return []
     topic_terms = _topic_terms(topic_text)
-    candidates: list[tuple[int, str]] = []
+    candidates: list[tuple[int, datetime | None, str]] = []
     seen_links: set[str] = set()
     for row in contact_rows:
         title = str(
@@ -290,10 +304,13 @@ def _rank_related_meeting_notes(
             continue
         seen_links.add(link)
         score = _meeting_note_score(title=title, date=date, topic_terms=topic_terms)
-        candidates.append((score, f"{title}｜{date or '日期未提供'}｜{link}"))
+        candidates.append((score, _parse_note_date(date), f"{title}｜{date or '日期未提供'}｜{link}"))
 
-    candidates.sort(key=lambda item: item[0], reverse=True)
-    return [item[1] for item in candidates[:limit]]
+    candidates.sort(
+        key=lambda item: (item[0], item[1] if item[1] is not None else datetime.min),
+        reverse=True,
+    )
+    return [item[2] for item in candidates[:limit]]
 
 
 def _topic_terms(text: str) -> set[str]:
@@ -310,13 +327,6 @@ def _meeting_note_score(*, title: str, date: str, topic_terms: set[str]) -> int:
     score = overlap * 10
     if date:
         score += 3
-        note_dt = _parse_note_date(date)
-        if note_dt is not None:
-            days = abs((datetime.utcnow() - note_dt).days)
-            if days <= 30:
-                score += 20
-            elif days <= 90:
-                score += 10
     return score
 
 

--- a/evals/meeting_output_bridge.py
+++ b/evals/meeting_output_bridge.py
@@ -158,10 +158,11 @@ def run_confirmed_todo_write(
 ) -> list[WriteExecutionResult]:
     results: list[WriteExecutionResult] = []
     for candidate in candidates:
+        target_object = candidate.target_object or "todo"
         if candidate.operation == "update":
             results.append(
                 WriteExecutionResult(
-                    target_object=candidate.target_object,
+                    target_object=target_object,
                     attempted=False,
                     allowed=False,
                     preflight_status="safe",

--- a/references/feishu-workbench-gateway.md
+++ b/references/feishu-workbench-gateway.md
@@ -18,6 +18,7 @@ The gateway unifies these responsibilities:
 2. resolve the customer and `客户ID`
 3. run targeted live reads only when the scenario explicitly requests them
 4. run live safety checks before write planning
+5. hand confirmed write candidates to the unified writer surface
 
 Any scenario that needs Feishu context should go through this gateway rather than improvising its own read path.
 
@@ -109,6 +110,15 @@ Examples:
 
 This stage is still planning, not mutation.
 
+The scenario layer should also attach:
+
+- `operation`
+- `match_basis`
+- `source_context`
+- `target_object`
+
+These fields are part of the shared write-candidate contract, not Todo-only details.
+
 ### Stage 5: Live Schema Preflight
 
 Before any write suggestion becomes write-ready:
@@ -143,6 +153,23 @@ If anything remains unsafe:
 - keep recommendation mode
 - do not escalate to write mode
 
+### Stage 7: Unified Writer Execution
+
+After explicit user confirmation:
+
+- pass the confirmed write candidate to the object-specific writer
+- do not let the scenario call Feishu mutation commands directly
+
+Writer responsibilities:
+
+- execute create or update
+- apply object-level dedupe
+- return a normalized write result
+
+Current first-class writer:
+
+- Todo writer
+
 ## Which scenarios must call the gateway
 
 These scenarios should use the gateway by default:
@@ -171,6 +198,7 @@ When the gateway is used, the final scenario output should make these items visi
 - `上下文恢复状态`
 - `已使用飞书资料`
 - `写入候选对象`
+- `统一写回结果`
 - `schema preflight 结果`
 - `blocked / drift`
 

--- a/references/task-patterns.md
+++ b/references/task-patterns.md
@@ -83,7 +83,13 @@ Write candidate interface:
 
 - if the scenario proposes a Base update, it should produce an explicit target table and field payload before calling live preflight
 - if the scenario proposes a Todo create or update, it should produce an explicit Todo candidate with owner, summary, and any custom fields before calling the Todo writer
+- Todo candidate should also carry:
+  - `operation`
+  - `match_basis`
+  - `source_context`
+  - `target_object`
 - the scenario layer, not the foundation, is responsible for deciding which objects to touch
+- the scenario layer should not call Feishu mutation commands directly; confirmed writes must go through the unified writer
 
 For the final user-facing structure:
 
@@ -160,6 +166,15 @@ Process:
    - `优先级` custom field
 4. Search existing tasks for semantic near-duplicates, not just exact title matches
 5. If an existing task already covers the same core job:
-   - update the existing task when the new input mainly adds scope, timing, or clarity
-   - create a subtask when the new input is one execution step under an existing broader task
+  - update the existing task when the new input mainly adds scope, timing, or clarity
+  - create a subtask when the new input is one execution step under an existing broader task
 6. Only create a new top-level task when there is no strong semantic overlap
+
+Current runtime implementation note:
+
+- the unified Todo writer currently returns one of:
+  - `create_new`
+  - `update_existing`
+  - `create_subtask`
+  - `no_write`
+- current first-pass semantic dedupe is intentionally minimal and should be treated as a safe starting point, not the final recall strategy

--- a/runtime/__init__.py
+++ b/runtime/__init__.py
@@ -22,7 +22,7 @@ from .semantic_registry import (
 )
 from .todo_writer import TodoWriter
 from .write_guard import WriteGuard
-from .models import WriteCandidate
+from .models import WriteCandidate, WriteExecutionResult
 
 __all__ = [
     "CustomerResolver",
@@ -41,6 +41,7 @@ __all__ = [
     "TABLE_PROFILES",
     "TodoWriter",
     "WriteCandidate",
+    "WriteExecutionResult",
     "WriteGuard",
     "build_live_diagnostic",
     "get_integrated_base_tables",

--- a/runtime/models.py
+++ b/runtime/models.py
@@ -10,6 +10,10 @@ Status = Literal["resolved", "partial", "unresolved"]
 PreflightStatus = Literal["safe", "safe_with_drift", "blocked"]
 CapabilityStatus = Literal["available", "degraded", "unavailable"]
 TableRole = Literal["snapshot", "detail", "dimension", "bridge"]
+WriteOperation = Literal["create", "update"]
+DedupeDecision = Literal["create_new", "update_existing", "create_subtask", "no_write"]
+GuardStatus = Literal["allowed", "blocked"]
+ExecutedOperation = Literal["create", "update", "blocked", "no_write"]
 
 
 @dataclass
@@ -87,6 +91,10 @@ class WriteCandidate:
     layer: Literal["snapshot", "detail", "archive", "reminder"]
     semantic_fields: list[str] = field(default_factory=list)
     payload: dict[str, Any] = field(default_factory=dict)
+    operation: WriteOperation = "create"
+    match_basis: dict[str, Any] = field(default_factory=dict)
+    source_context: dict[str, Any] = field(default_factory=dict)
+    target_object: str | None = None
 
 
 @dataclass
@@ -127,14 +135,33 @@ class GuardResult:
 
 
 @dataclass
-class TodoWriteResult:
+class WriteExecutionResult:
+    target_object: str
     attempted: bool
     allowed: bool
-    preflight_report: PreflightReport
-    guard_result: GuardResult
-    task_guid: str | None = None
-    task_url: str | None = None
+    preflight_status: PreflightStatus | None = None
+    guard_status: GuardStatus | None = None
+    dedupe_decision: DedupeDecision = "create_new"
+    executed_operation: ExecutedOperation = "no_write"
+    remote_object_id: str | None = None
+    remote_url: str | None = None
+    blocked_reasons: list[str] = field(default_factory=list)
+    drift_items: list[str] = field(default_factory=list)
+    source_context: dict[str, Any] = field(default_factory=dict)
+    preflight_report: PreflightReport | None = None
+    guard_result: GuardResult | None = None
     request_payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TodoWriteResult(WriteExecutionResult):
+    @property
+    def task_guid(self) -> str | None:
+        return self.remote_object_id
+
+    @property
+    def task_url(self) -> str | None:
+        return self.remote_url
 
 
 @dataclass
@@ -158,3 +185,4 @@ class GatewayResult:
     write_candidates: list[WriteCandidate] = field(default_factory=list)
     preflight_reports: list[PreflightReport] = field(default_factory=list)
     guard_results: list[GuardResult] = field(default_factory=list)
+    write_results: list[WriteExecutionResult] = field(default_factory=list)

--- a/runtime/todo_writer.py
+++ b/runtime/todo_writer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+import re
 
 from .lark_cli import LarkCliClient
 from .live_adapter import LarkCliSchemaBackend, LiveWorkbenchConfig
@@ -20,11 +21,13 @@ class TodoWriter:
         config: LiveWorkbenchConfig,
         schema_preflight: SchemaPreflightRunner,
         write_guard: WriteGuard | None = None,
+        existing_tasks: list[dict[str, object]] | None = None,
     ) -> None:
         self.client = client
         self.config = config
         self.schema_preflight = schema_preflight
         self.write_guard = write_guard or WriteGuard()
+        self.existing_tasks = existing_tasks or []
 
     @classmethod
     def for_live_lark_cli(cls, repo_root: str) -> "TodoWriter":
@@ -39,11 +42,49 @@ class TodoWriter:
 
     def create(self, candidate: WriteCandidate) -> TodoWriteResult:
         report = self.schema_preflight.run(candidate)
+        duplicate_task = self._find_duplicate_task(candidate)
+        if duplicate_task:
+            duplicate_task_guid = str(duplicate_task.get("guid") or "")
+            decision = self._decide_duplicate_action(candidate, duplicate_task)
+            if decision == "create_subtask":
+                if self._should_execute_create_subtask(candidate):
+                    return self._create_subtask(
+                        parent_task_guid=duplicate_task_guid,
+                        candidate=candidate,
+                        report=report,
+                    )
+                return TodoWriteResult(
+                    target_object=candidate.target_object or "todo",
+                    attempted=False,
+                    allowed=False,
+                    preflight_status=report.status,
+                    guard_status="blocked",
+                    dedupe_decision="create_subtask",
+                    executed_operation="blocked",
+                    remote_object_id=duplicate_task_guid or None,
+                    blocked_reasons=["semantic_duplicate_detected", "subtask_recommended"],
+                    drift_items=self._collect_drift_items(report),
+                    source_context=dict(candidate.source_context),
+                    preflight_report=report,
+                )
+            update_candidate = self._build_duplicate_update_candidate(candidate)
+            result = self.update(duplicate_task_guid, update_candidate)
+            result.dedupe_decision = "update_existing"
+            return result
+
         guard = self.write_guard.evaluate(candidate, report, owner_required=True)
         if not guard.allowed:
             return TodoWriteResult(
+                target_object=candidate.target_object or "todo",
                 attempted=False,
                 allowed=False,
+                preflight_status=report.status,
+                guard_status="blocked",
+                dedupe_decision="no_write",
+                executed_operation="blocked",
+                blocked_reasons=list(dict.fromkeys(guard.reasons)),
+                drift_items=self._collect_drift_items(report),
+                source_context=dict(candidate.source_context),
                 preflight_report=report,
                 guard_result=guard,
             )
@@ -61,12 +102,19 @@ class TodoWriter:
         data = response.get("data") if isinstance(response.get("data"), dict) else {}
         task = data.get("task") if isinstance(data, dict) and isinstance(data.get("task"), dict) else {}
         return TodoWriteResult(
+            target_object=candidate.target_object or "todo",
             attempted=True,
             allowed=True,
+            preflight_status=report.status,
+            guard_status="allowed",
+            dedupe_decision="create_new",
+            executed_operation="create",
+            remote_object_id=str(task.get("guid")) if task.get("guid") is not None else None,
+            remote_url=str(task.get("url")) if task.get("url") is not None else None,
+            drift_items=self._collect_drift_items(report),
+            source_context=dict(candidate.source_context),
             preflight_report=report,
             guard_result=guard,
-            task_guid=str(task.get("guid")) if task.get("guid") is not None else None,
-            task_url=str(task.get("url")) if task.get("url") is not None else None,
             request_payload=request_payload,
         )
 
@@ -75,8 +123,16 @@ class TodoWriter:
         guard = self.write_guard.evaluate(candidate, report, owner_required=False)
         if not guard.allowed:
             return TodoWriteResult(
+                target_object=candidate.target_object or "todo",
                 attempted=False,
                 allowed=False,
+                preflight_status=report.status,
+                guard_status="blocked",
+                dedupe_decision="no_write",
+                executed_operation="blocked",
+                blocked_reasons=list(dict.fromkeys(guard.reasons)),
+                drift_items=self._collect_drift_items(report),
+                source_context=dict(candidate.source_context),
                 preflight_report=report,
                 guard_result=guard,
             )
@@ -114,12 +170,19 @@ class TodoWriter:
                 task = self._get_task(task_guid)
 
         return TodoWriteResult(
+            target_object=candidate.target_object or "todo",
             attempted=True,
             allowed=True,
+            preflight_status=report.status,
+            guard_status="allowed",
+            dedupe_decision="update_existing",
+            executed_operation="update",
+            remote_object_id=str(task.get("guid")) if task.get("guid") is not None else task_guid,
+            remote_url=str(task.get("url")) if task.get("url") is not None else None,
+            drift_items=self._collect_drift_items(report),
+            source_context=dict(candidate.source_context),
             preflight_report=report,
             guard_result=guard,
-            task_guid=str(task.get("guid")) if task.get("guid") is not None else task_guid,
-            task_url=str(task.get("url")) if task.get("url") is not None else None,
             request_payload=request_payload,
         )
 
@@ -139,6 +202,13 @@ class TodoWriter:
         custom_fields = self._build_custom_fields(payload)
         if custom_fields:
             request["custom_fields"] = custom_fields
+        return request
+
+    def _build_subtask_create_payload(
+        self, parent_task_guid: str, candidate: WriteCandidate
+    ) -> dict[str, object]:
+        request = self._build_create_payload(candidate)
+        request["parent_task_guid"] = parent_task_guid
         return request
 
     def _build_patch_payload(
@@ -319,3 +389,204 @@ class TodoWriter:
         if owner_payload is None:
             return None
         return str(owner_payload)
+
+    def _collect_drift_items(self, report) -> list[str]:
+        return [
+            item
+            for field_result in report.field_results
+            for item in field_result.drift_items
+        ]
+
+    def _should_execute_create_subtask(self, candidate: WriteCandidate) -> bool:
+        flag = candidate.source_context.get("confirm_create_subtask")
+        return bool(flag)
+
+    def _create_subtask(
+        self,
+        *,
+        parent_task_guid: str,
+        candidate: WriteCandidate,
+        report,
+    ) -> TodoWriteResult:
+        guard = self.write_guard.evaluate(candidate, report, owner_required=True)
+        if not guard.allowed:
+            reasons = list(dict.fromkeys([*guard.reasons, "subtask_confirmed_but_guard_blocked"]))
+            return TodoWriteResult(
+                target_object=candidate.target_object or "todo",
+                attempted=False,
+                allowed=False,
+                preflight_status=report.status,
+                guard_status="blocked",
+                dedupe_decision="create_subtask",
+                executed_operation="blocked",
+                remote_object_id=parent_task_guid or None,
+                blocked_reasons=reasons,
+                drift_items=self._collect_drift_items(report),
+                source_context=dict(candidate.source_context),
+                preflight_report=report,
+                guard_result=guard,
+            )
+
+        request_payload = self._build_subtask_create_payload(parent_task_guid, candidate)
+        response = self.client.invoke_json(
+            [
+                "task",
+                "tasks",
+                "create",
+                "--data",
+                json.dumps(request_payload, ensure_ascii=False),
+            ]
+        )
+        data = response.get("data") if isinstance(response.get("data"), dict) else {}
+        task = data.get("task") if isinstance(data, dict) and isinstance(data.get("task"), dict) else {}
+        return TodoWriteResult(
+            target_object=candidate.target_object or "todo",
+            attempted=True,
+            allowed=True,
+            preflight_status=report.status,
+            guard_status="allowed",
+            dedupe_decision="create_subtask",
+            executed_operation="create",
+            remote_object_id=str(task.get("guid")) if task.get("guid") is not None else None,
+            remote_url=str(task.get("url")) if task.get("url") is not None else None,
+            blocked_reasons=[],
+            drift_items=self._collect_drift_items(report),
+            source_context=dict(candidate.source_context),
+            preflight_report=report,
+            guard_result=guard,
+            request_payload=request_payload,
+        )
+
+    def _find_duplicate_task(self, candidate: WriteCandidate) -> dict[str, object] | None:
+        summary = str(candidate.payload.get("summary") or "").strip()
+        customer = str(
+            candidate.match_basis.get("customer")
+            or candidate.payload.get("customer")
+            or ""
+        ).strip()
+        due_at = str(
+            candidate.match_basis.get("time_window")
+            or candidate.payload.get("due_at")
+            or ""
+        ).strip()
+        candidate_terms = self._normalize_terms(summary)
+        if not summary or not customer or not candidate_terms:
+            return None
+
+        best_match: dict[str, object] | None = None
+        best_overlap = 0
+        for task in self.existing_tasks:
+            task_customer = str(task.get("customer") or "").strip()
+            if task_customer != customer:
+                continue
+            existing_terms = self._normalize_terms(str(task.get("summary") or ""))
+            if not existing_terms:
+                continue
+            if not self._is_same_time_window(due_at, str(task.get("due_at") or "")):
+                continue
+            overlap = len(candidate_terms.intersection(existing_terms))
+            if overlap >= 2 and overlap > best_overlap:
+                best_overlap = overlap
+                best_match = task
+        return best_match
+
+    def _decide_duplicate_action(
+        self,
+        candidate: WriteCandidate,
+        existing_task: dict[str, object],
+    ) -> str:
+        candidate_terms = self._normalize_terms(str(candidate.payload.get("summary") or ""))
+        existing_terms = self._normalize_terms(str(existing_task.get("summary") or ""))
+        if not candidate_terms or not existing_terms:
+            return "update_existing"
+
+        overlap = len(candidate_terms.intersection(existing_terms))
+        ratio = overlap / max(1, min(len(candidate_terms), len(existing_terms)))
+        candidate_has_execution_detail = self._has_execution_detail_signal(candidate_terms)
+        existing_has_parent_scope = self._has_parent_scope_signal(existing_terms)
+
+        if ratio >= 0.75 and candidate_has_execution_detail and existing_has_parent_scope:
+            return "create_subtask"
+        return "update_existing"
+
+    def _build_duplicate_update_candidate(self, candidate: WriteCandidate) -> WriteCandidate:
+        patchable_fields = ["summary", "description", "due_at", "customer", "priority"]
+        payload = {
+            key: value
+            for key, value in candidate.payload.items()
+            if key in patchable_fields
+        }
+        semantic_fields = [
+            field
+            for field in candidate.semantic_fields
+            if field in patchable_fields
+        ]
+        return WriteCandidate(
+            object_name=candidate.object_name,
+            target_object=candidate.target_object,
+            layer=candidate.layer,
+            operation="update",
+            semantic_fields=semantic_fields,
+            payload=payload,
+            match_basis=dict(candidate.match_basis),
+            source_context=dict(candidate.source_context),
+        )
+
+    def _normalize_terms(self, summary: str) -> set[str]:
+        normalized = summary.lower()
+        normalized = re.sub(r"[（）()｜|,，/\\:：_\\-]+", " ", normalized)
+        normalized = re.sub(r"[·•。；;!！?？\[\]{}]+", " ", normalized)
+        normalized = re.sub(r"([a-z0-9]+)([\u4e00-\u9fff])", r"\1 \2", normalized)
+        normalized = re.sub(r"([\u4e00-\u9fff])([a-z0-9]+)", r"\1 \2", normalized)
+        for token in ("方案", "确认", "推进", "跟进", "续费", "沟通", "处理", "更新"):
+            normalized = normalized.replace(token, f" {token} ")
+        synonym_map = {
+            "campaign": "活动",
+            "复盘": "总结",
+            "会前包": "会前资料",
+        }
+        for src, dst in synonym_map.items():
+            normalized = normalized.replace(src, dst)
+        parts = [part for part in re.split(r"[\s｜|,，/]+", normalized) if part]
+        stop_words = {"的", "和", "并", "及", "请", "帮", "一下"}
+        terms = {part for part in parts if part not in stop_words}
+
+        # Add CJK bi-grams for long continuous Chinese fragments to improve recall.
+        for part in list(terms):
+            if re.fullmatch(r"[\u4e00-\u9fff]{4,}", part):
+                for idx in range(len(part) - 1):
+                    terms.add(part[idx : idx + 2])
+        return terms
+
+    def _has_execution_detail_signal(self, terms: set[str]) -> bool:
+        detail_tokens = {
+            "整理",
+            "同步",
+            "提交",
+            "发送",
+            "对齐",
+            "准备",
+            "资料",
+            "清单",
+            "文档",
+            "邮件",
+        }
+        return any(token in terms for token in detail_tokens)
+
+    def _has_parent_scope_signal(self, terms: set[str]) -> bool:
+        scope_tokens = {
+            "项目",
+            "计划",
+            "方案",
+            "策略",
+            "推进",
+            "跟进",
+        }
+        return any(token in terms for token in scope_tokens)
+
+    def _is_same_time_window(self, candidate_due_at: str, existing_due_at: str) -> bool:
+        if not candidate_due_at or not existing_due_at:
+            return True
+        candidate_window = candidate_due_at[:7]
+        existing_window = existing_due_at[:7]
+        return candidate_window == existing_window

--- a/runtime/todo_writer.py
+++ b/runtime/todo_writer.py
@@ -45,32 +45,35 @@ class TodoWriter:
         duplicate_task = self._find_duplicate_task(candidate)
         if duplicate_task:
             duplicate_task_guid = str(duplicate_task.get("guid") or "")
-            decision = self._decide_duplicate_action(candidate, duplicate_task)
-            if decision == "create_subtask":
-                if self._should_execute_create_subtask(candidate):
-                    return self._create_subtask(
-                        parent_task_guid=duplicate_task_guid,
-                        candidate=candidate,
-                        report=report,
+            if not duplicate_task_guid:
+                duplicate_task = None
+            else:
+                decision = self._decide_duplicate_action(candidate, duplicate_task)
+                if decision == "create_subtask":
+                    if self._should_execute_create_subtask(candidate):
+                        return self._create_subtask(
+                            parent_task_guid=duplicate_task_guid,
+                            candidate=candidate,
+                            report=report,
+                        )
+                    return TodoWriteResult(
+                        target_object=candidate.target_object or "todo",
+                        attempted=False,
+                        allowed=False,
+                        preflight_status=report.status,
+                        guard_status="blocked",
+                        dedupe_decision="create_subtask",
+                        executed_operation="blocked",
+                        remote_object_id=duplicate_task_guid or None,
+                        blocked_reasons=["semantic_duplicate_detected", "subtask_recommended"],
+                        drift_items=self._collect_drift_items(report),
+                        source_context=dict(candidate.source_context),
+                        preflight_report=report,
                     )
-                return TodoWriteResult(
-                    target_object=candidate.target_object or "todo",
-                    attempted=False,
-                    allowed=False,
-                    preflight_status=report.status,
-                    guard_status="blocked",
-                    dedupe_decision="create_subtask",
-                    executed_operation="blocked",
-                    remote_object_id=duplicate_task_guid or None,
-                    blocked_reasons=["semantic_duplicate_detected", "subtask_recommended"],
-                    drift_items=self._collect_drift_items(report),
-                    source_context=dict(candidate.source_context),
-                    preflight_report=report,
-                )
-            update_candidate = self._build_duplicate_update_candidate(candidate)
-            result = self.update(duplicate_task_guid, update_candidate)
-            result.dedupe_decision = "update_existing"
-            return result
+                update_candidate = self._build_duplicate_update_candidate(candidate)
+                result = self.update(duplicate_task_guid, update_candidate)
+                result.dedupe_decision = "update_existing"
+                return result
 
         guard = self.write_guard.evaluate(candidate, report, owner_required=True)
         if not guard.allowed:
@@ -586,7 +589,7 @@ class TodoWriter:
 
     def _is_same_time_window(self, candidate_due_at: str, existing_due_at: str) -> bool:
         if not candidate_due_at or not existing_due_at:
-            return True
+            return False
         candidate_window = candidate_due_at[:7]
         existing_window = existing_due_at[:7]
         return candidate_window == existing_window

--- a/runtime/todo_writer.py
+++ b/runtime/todo_writer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 import re
 
 from .lark_cli import LarkCliClient
@@ -291,12 +291,14 @@ class TodoWriter:
                 return {"timestamp": raw, "is_all_day": False}
             try:
                 if len(raw) == 10:
-                    dt = datetime.strptime(raw, "%Y-%m-%d")
+                    dt = datetime.strptime(raw, "%Y-%m-%d").replace(tzinfo=timezone.utc)
                     return {
                         "timestamp": str(int(dt.timestamp() * 1000)),
                         "is_all_day": True,
                     }
                 dt = datetime.fromisoformat(raw)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
                 return {
                     "timestamp": str(int(dt.timestamp() * 1000)),
                     "is_all_day": False,

--- a/tests/test_meeting_output_bridge.py
+++ b/tests/test_meeting_output_bridge.py
@@ -124,6 +124,7 @@ class MeetingOutputBridgeTests(unittest.TestCase):
         self.assertEqual(candidate.operation, "create")
         self.assertEqual(candidate.source_context["scenario"], "post_meeting")
         self.assertEqual(candidate.match_basis["customer"], "联合利华")
+        self.assertEqual(candidate.match_basis["time_window"], "2026-04")
         self.assertNotIn("owner", candidate.payload)
 
     def test_run_confirmed_todo_write_uses_unified_todo_writer(self) -> None:
@@ -168,6 +169,30 @@ class MeetingOutputBridgeTests(unittest.TestCase):
         self.assertEqual(writer.calls[0].target_object, "todo")
         self.assertEqual(results[0].executed_operation, "create")
         self.assertEqual(results[0].remote_object_id, "task_guid_1")
+
+    def test_run_confirmed_todo_write_blocks_update_candidates(self) -> None:
+        class FakeTodoWriter:
+            def create(self, candidate):
+                raise AssertionError("update candidate should not call create")
+
+        candidate = build_meeting_todo_candidates(
+            eval_name="unilever-stage-review",
+            gateway_result=GatewayResult(
+                resource_resolution=ResourceResolution(status="resolved"),
+                customer_resolution=CustomerResolution(
+                    status="resolved",
+                    query="联合利华",
+                    candidates=[CustomerMatch(customer_id="C_002", short_name="联合利华")],
+                ),
+            ),
+        )[0]
+        candidate.operation = "update"
+
+        results = run_confirmed_todo_write(candidates=[candidate], todo_writer=FakeTodoWriter())
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].executed_operation, "blocked")
+        self.assertIn("update_operation_not_supported_in_confirmed_write", results[0].blocked_reasons)
 
     def test_recover_live_context_reads_minimum_base_sources(self) -> None:
         class FakeQueryBackend:

--- a/tests/test_meeting_output_bridge.py
+++ b/tests/test_meeting_output_bridge.py
@@ -264,6 +264,47 @@ class MeetingOutputBridgeTests(unittest.TestCase):
         self.assertEqual(len(note_lines), 1)
         self.assertIn("note-1", note_lines[0])
 
+    def test_recover_live_context_prefers_recent_note_when_titles_are_similar(self) -> None:
+        class FakeQueryBackend:
+            def query_rows_by_customer_id(self, table_name: str, customer_id: str, limit: int = 20):
+                if table_name == "客户联系记录":
+                    return [
+                        {
+                            "客户ID": customer_id,
+                            "记录标题": "联合利华｜月度复盘汇报",
+                            "联系日期": "2024-04-10",
+                            "会议纪要链接": "https://doc.example/old-note",
+                        },
+                        {
+                            "客户ID": customer_id,
+                            "记录标题": "联合利华｜月度复盘汇报",
+                            "联系日期": "2026-04-10",
+                            "会议纪要链接": "https://doc.example/new-note",
+                        },
+                    ]
+                if table_name == "行动计划":
+                    return [{"客户ID": customer_id, "具体行动": "复盘沟通", "计划完成时间": "2026-04-20"}]
+                return []
+
+        gateway_result = GatewayResult(
+            resource_resolution=ResourceResolution(status="resolved"),
+            capability_report=CapabilityReport(),
+            customer_resolution=CustomerResolution(
+                status="resolved",
+                query="联合利华",
+                candidates=[CustomerMatch(customer_id="C_002", short_name="联合利华")],
+            ),
+        )
+
+        context = recover_live_context(
+            gateway_result=gateway_result,
+            query_backend=FakeQueryBackend(),
+            topic_text="联合利华 月度复盘",
+        )
+        note_lines = [line for line in context["key_context"] if line.startswith("相关会议纪要候选:")]
+        self.assertEqual(len(note_lines), 1)
+        self.assertTrue(note_lines[0].index("new-note") < note_lines[0].index("old-note"))
+
     def test_gateway_execution_marks_unilever_context_as_partial_until_stage3_reads_exist(self) -> None:
         class FakeGateway:
             def run(self, customer_query: str):

--- a/tests/test_meeting_output_bridge.py
+++ b/tests/test_meeting_output_bridge.py
@@ -24,15 +24,56 @@ from runtime.models import (  # noqa: E402
     GatewayResult,
     ResourceHint,
     ResourceResolution,
+    WriteExecutionResult,
 )
 
 from evals.meeting_output_bridge import build_meeting_output  # noqa: E402
 from evals.meeting_output_bridge import main as bridge_main  # noqa: E402
+from evals.meeting_output_bridge import build_meeting_todo_candidates  # noqa: E402
 from evals.meeting_output_bridge import recover_live_context  # noqa: E402
+from evals.meeting_output_bridge import run_confirmed_todo_write  # noqa: E402
 from evals.meeting_output_bridge import run_gateway_and_build_meeting_output  # noqa: E402
 
 
 class MeetingOutputBridgeTests(unittest.TestCase):
+    def test_build_meeting_output_includes_write_result_summary(self) -> None:
+        gateway_result = GatewayResult(
+            resource_resolution=ResourceResolution(status="resolved"),
+            capability_report=CapabilityReport(),
+            customer_resolution=CustomerResolution(
+                status="resolved",
+                query="联合利华",
+                candidates=[CustomerMatch(customer_id="C_002", short_name="联合利华")],
+            ),
+        )
+
+        output_text = build_meeting_output(
+            eval_name="unilever-stage-review",
+            transcript_path=UNILEVER_TRANSCRIPT,
+            gateway_result=gateway_result,
+            context_status="partial",
+            used_sources=["客户主数据"],
+            write_results=[
+                WriteExecutionResult(
+                    target_object="todo",
+                    attempted=False,
+                    allowed=False,
+                    preflight_status="safe",
+                    guard_status="allowed",
+                    dedupe_decision="update_existing",
+                    executed_operation="blocked",
+                    remote_object_id="task_existing",
+                    blocked_reasons=["semantic_duplicate_detected"],
+                    source_context={"scenario": "post_meeting"},
+                )
+            ],
+        )
+
+        self.assertIn("统一写回结果:", output_text)
+        self.assertIn("- todo: blocked", output_text)
+        self.assertIn("dedupe=update_existing", output_text)
+        self.assertIn("blocked=semantic_duplicate_detected", output_text)
+
     def test_build_meeting_output_handles_missing_transcript_file(self) -> None:
         gateway_result = GatewayResult(
             resource_resolution=ResourceResolution(status="resolved"),
@@ -60,6 +101,73 @@ class MeetingOutputBridgeTests(unittest.TestCase):
         self.assertIn("Transcript source: feishu-am-workbench-missing-transcript.txt", output_text)
         self.assertIn("Transcript status: missing", output_text)
         self.assertIn("fallback 原因: transcript file not available in current environment", output_text)
+
+    def test_build_meeting_todo_candidates_returns_recommendation_mode_candidate(self) -> None:
+        gateway_result = GatewayResult(
+            resource_resolution=ResourceResolution(status="resolved"),
+            capability_report=CapabilityReport(),
+            customer_resolution=CustomerResolution(
+                status="resolved",
+                query="联合利华",
+                candidates=[CustomerMatch(customer_id="C_002", short_name="联合利华")],
+            ),
+        )
+
+        candidates = build_meeting_todo_candidates(
+            eval_name="unilever-stage-review",
+            gateway_result=gateway_result,
+        )
+
+        self.assertEqual(len(candidates), 1)
+        candidate = candidates[0]
+        self.assertEqual(candidate.target_object, "todo")
+        self.assertEqual(candidate.operation, "create")
+        self.assertEqual(candidate.source_context["scenario"], "post_meeting")
+        self.assertEqual(candidate.match_basis["customer"], "联合利华")
+        self.assertNotIn("owner", candidate.payload)
+
+    def test_run_confirmed_todo_write_uses_unified_todo_writer(self) -> None:
+        class FakeTodoWriter:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def create(self, candidate):
+                self.calls.append(candidate)
+                return WriteExecutionResult(
+                    target_object="todo",
+                    attempted=True,
+                    allowed=True,
+                    preflight_status="safe",
+                    guard_status="allowed",
+                    dedupe_decision="create_new",
+                    executed_operation="create",
+                    remote_object_id="task_guid_1",
+                    remote_url="https://applink.feishu.cn/client/todo/detail?guid=task_guid_1",
+                    source_context=dict(candidate.source_context),
+                )
+
+        candidate = build_meeting_todo_candidates(
+            eval_name="unilever-stage-review",
+            gateway_result=GatewayResult(
+                resource_resolution=ResourceResolution(status="resolved"),
+                customer_resolution=CustomerResolution(
+                    status="resolved",
+                    query="联合利华",
+                    candidates=[CustomerMatch(customer_id="C_002", short_name="联合利华")],
+                ),
+            ),
+        )[0]
+
+        writer = FakeTodoWriter()
+        results = run_confirmed_todo_write(
+            candidates=[candidate],
+            todo_writer=writer,
+        )
+
+        self.assertEqual(len(writer.calls), 1)
+        self.assertEqual(writer.calls[0].target_object, "todo")
+        self.assertEqual(results[0].executed_operation, "create")
+        self.assertEqual(results[0].remote_object_id, "task_guid_1")
 
     def test_recover_live_context_reads_minimum_base_sources(self) -> None:
         class FakeQueryBackend:
@@ -104,6 +212,57 @@ class MeetingOutputBridgeTests(unittest.TestCase):
         )
         self.assertIn("最近联系记录: 2026-04-09｜联合利华｜阶段汇报跟进", context["key_context"])
         self.assertIn("当前行动计划: 推进 Campaign 优化方案确认｜2026-04-20", context["key_context"])
+
+    def test_recover_live_context_includes_ranked_related_meeting_notes(self) -> None:
+        class FakeQueryBackend:
+            def query_rows_by_customer_id(self, table_name: str, customer_id: str, limit: int = 20):
+                if table_name == "客户联系记录":
+                    return [
+                        {
+                            "客户ID": customer_id,
+                            "记录标题": "联合利华｜Campaign活动分析优化阶段汇报",
+                            "联系日期": "2026-04-10",
+                            "会议纪要链接": "https://doc.example/note-1",
+                        },
+                        {
+                            "客户ID": customer_id,
+                            "记录标题": "联合利华｜季度复盘沟通",
+                            "联系日期": "2026-04-05",
+                            "会议纪要链接": "https://doc.example/note-2",
+                        },
+                    ]
+                if table_name == "行动计划":
+                    return [
+                        {"客户ID": customer_id, "具体行动": "推进优化方案", "计划完成时间": "2026-04-20"},
+                    ]
+                return []
+
+        gateway_result = GatewayResult(
+            resource_resolution=ResourceResolution(status="resolved"),
+            capability_report=CapabilityReport(),
+            customer_resolution=CustomerResolution(
+                status="resolved",
+                query="联合利华",
+                candidates=[
+                    CustomerMatch(
+                        customer_id="C_002",
+                        short_name="联合利华",
+                        archive_link="https://doc.example/unilever",
+                    )
+                ],
+            ),
+        )
+
+        context = recover_live_context(
+            gateway_result=gateway_result,
+            query_backend=FakeQueryBackend(),
+            topic_text="20260410-联合利华 Campaign活动分析优化-阶段汇报",
+        )
+
+        self.assertIn("相关会议纪要候选", context["used_sources"])
+        note_lines = [line for line in context["key_context"] if line.startswith("相关会议纪要候选:")]
+        self.assertEqual(len(note_lines), 1)
+        self.assertIn("note-1", note_lines[0])
 
     def test_gateway_execution_marks_unilever_context_as_partial_until_stage3_reads_exist(self) -> None:
         class FakeGateway:

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -1354,6 +1354,174 @@ class RuntimeSmokeTests(unittest.TestCase):
         self.assertNotIn("member_add", result.request_payload)
         self.assertNotIn("member_remove", result.request_payload)
 
+    def test_todo_writer_ignores_duplicate_without_guid(self) -> None:
+        class FakeClient:
+            def invoke_json(self, argv: list[str]) -> dict[str, object]:
+                if argv[:3] == ["task", "tasks", "create"]:
+                    return {
+                        "code": 0,
+                        "data": {
+                            "task": {
+                                "guid": "task_new",
+                                "url": "https://applink.feishu.cn/client/todo/detail?guid=task_new",
+                            }
+                        },
+                    }
+                raise AssertionError(f"unexpected command: {' '.join(argv)}")
+
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "owner": {
+                        "field_id": "members.assignee",
+                        "name": "负责人",
+                        "type": "user",
+                        "allowed_live_types": ["user"],
+                        "write_policy": "required_create",
+                        "valid_member_ids": ["ou_owner"],
+                    },
+                    "customer": {
+                        "field_id": "a7009aff-7d85-4378-82c9-1584873f469d",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                    "priority": {
+                        "field_id": "f7587037-8ad1-443c-b350-f6600e0ccadd",
+                        "name": "优先级",
+                        "type": "single_select",
+                        "options": ["高", "中", "低"],
+                        "allowed_live_types": ["single_select"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=FakeClient(),
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "summary": "跟进联合利华 Campaign 优化方案确认",
+                    "customer": "联合利华",
+                    "due_at": "2026-04-10",
+                }
+            ],
+        )
+
+        candidate = WriteCandidate(
+            object_name="待办",
+            target_object="todo",
+            layer="reminder",
+            operation="create",
+            semantic_fields=["summary", "owner", "customer", "priority"],
+            payload={
+                "summary": "跟进联合利华 Campaign 优化方案确认",
+                "owner": "ou_owner",
+                "customer": "联合利华",
+                "priority": "高",
+            },
+            match_basis={"customer": "联合利华", "time_window": "2026-04"},
+        )
+
+        result = writer.create(candidate)
+        self.assertTrue(result.attempted)
+        self.assertEqual(result.executed_operation, "create")
+        self.assertEqual(result.dedupe_decision, "create_new")
+        self.assertEqual(result.remote_object_id, "task_new")
+
+    def test_todo_writer_requires_time_window_for_duplicate_matching(self) -> None:
+        class FakeClient:
+            def invoke_json(self, argv: list[str]) -> dict[str, object]:
+                if argv[:3] == ["task", "tasks", "create"]:
+                    return {
+                        "code": 0,
+                        "data": {
+                            "task": {
+                                "guid": "task_new_no_window",
+                                "url": "https://applink.feishu.cn/client/todo/detail?guid=task_new_no_window",
+                            }
+                        },
+                    }
+                raise AssertionError(f"unexpected command: {' '.join(argv)}")
+
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "owner": {
+                        "field_id": "members.assignee",
+                        "name": "负责人",
+                        "type": "user",
+                        "allowed_live_types": ["user"],
+                        "write_policy": "required_create",
+                        "valid_member_ids": ["ou_owner"],
+                    },
+                    "customer": {
+                        "field_id": "a7009aff-7d85-4378-82c9-1584873f469d",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=FakeClient(),
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "guid": "task_existing",
+                    "summary": "跟进联合利华 Campaign 优化方案确认",
+                    "customer": "联合利华",
+                    "due_at": "2026-04-10",
+                }
+            ],
+        )
+
+        candidate = WriteCandidate(
+            object_name="待办",
+            target_object="todo",
+            layer="reminder",
+            operation="create",
+            semantic_fields=["summary", "owner", "customer"],
+            payload={
+                "summary": "跟进联合利华 Campaign 优化方案确认",
+                "owner": "ou_owner",
+                "customer": "联合利华",
+            },
+            match_basis={"customer": "联合利华"},
+        )
+
+        result = writer.create(candidate)
+        self.assertTrue(result.attempted)
+        self.assertEqual(result.executed_operation, "create")
+        self.assertEqual(result.dedupe_decision, "create_new")
+        self.assertEqual(result.remote_object_id, "task_new_no_window")
+
     def test_capability_report_degrades_when_required_table_missing(self) -> None:
         responses = {
             "base +table-list --base-token MKECbZiC4arRrbs6QlZcFj2Rn7b --limit 200": subprocess.CompletedProcess(

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -251,7 +251,7 @@ class RuntimeSmokeTests(unittest.TestCase):
             (
                 'task tasks patch --params {"task_guid": "task_existing"} --data '
                 '{"task": {"summary": "跟进联合利华续费方案", '
-                '"due": {"timestamp": "1776614400000", "is_all_day": true}, '
+                '"due": {"timestamp": "1776643200000", "is_all_day": true}, '
                 '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华"}, '
                 '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "d7aff674-0ef8-6397-9108-fb260e21bde9"}]}, '
                 '"update_fields": ["summary", "due", "custom_fields"]}'
@@ -1025,7 +1025,7 @@ class RuntimeSmokeTests(unittest.TestCase):
                 '{"summary": "跟进联合利华续费", "tasklists": [{"tasklist_guid": "e50dda19-63e4-410a-a167-6813f3b3c86d"}], '
                 '"members": [{"id": "ou_owner", "role": "assignee", "type": "user"}], '
                 '"description": "带客户档案链接", '
-                '"due": {"timestamp": "1776096000000", "is_all_day": true}, '
+                '"due": {"timestamp": "1776124800000", "is_all_day": true}, '
                 '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华"}, '
                 '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "d7aff674-0ef8-6397-9108-fb260e21bde9"}]}'
             ): subprocess.CompletedProcess(
@@ -1132,7 +1132,7 @@ class RuntimeSmokeTests(unittest.TestCase):
             (
                 'task tasks patch --params {"task_guid": "task_guid_1"} --data '
                 '{"task": {"summary": "更新后的标题", "description": "更新后的描述", '
-                '"due": {"timestamp": "1776096000000", "is_all_day": true}, '
+                '"due": {"timestamp": "1776124800000", "is_all_day": true}, '
                 '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华"}, '
                 '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "6238286f-b2e2-5ab8-e902-a3bb9dc242b0"}]}, '
                 '"update_fields": ["summary", "description", "due", "custom_fields"]}'
@@ -1258,7 +1258,7 @@ class RuntimeSmokeTests(unittest.TestCase):
             (
                 'task tasks patch --params {"task_guid": "task_existing"} --data '
                 '{"task": {"summary": "跟进联合利华 AI 埋点产品介绍给触脉确认", "description": "补充新的会后上下文", '
-                '"due": {"timestamp": "1776096000000", "is_all_day": true}, '
+                '"due": {"timestamp": "1776124800000", "is_all_day": true}, '
                 '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华（UFS）"}, '
                 '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "d7aff674-0ef8-6397-9108-fb260e21bde9"}]}, '
                 '"update_fields": ["summary", "description", "due", "custom_fields"]}'

--- a/tests/test_runtime_smoke.py
+++ b/tests/test_runtime_smoke.py
@@ -149,6 +149,413 @@ class FakeRunner:
 
 
 class RuntimeSmokeTests(unittest.TestCase):
+    def test_write_candidate_supports_shared_write_metadata(self) -> None:
+        candidate = WriteCandidate(
+            object_name="待办",
+            layer="reminder",
+            semantic_fields=["summary", "owner"],
+            payload={"summary": "跟进联合利华续费", "owner": "ou_owner"},
+            operation="create",
+            match_basis={"customer": "联合利华", "time_window": "2026-04"},
+            source_context={"scenario": "post_meeting", "customer_id": "C_002"},
+            target_object="todo",
+        )
+        self.assertEqual(candidate.operation, "create")
+        self.assertEqual(candidate.target_object, "todo")
+        self.assertEqual(candidate.match_basis["customer"], "联合利华")
+        self.assertEqual(candidate.source_context["scenario"], "post_meeting")
+
+    def test_todo_writer_returns_shared_execution_result_for_blocked_candidate(self) -> None:
+        class RaisingRunner:
+            def __call__(self, command, capture_output, text, check):
+                raise AssertionError("task create should not be invoked when preflight is blocked")
+
+        client = LarkCliClient(runner=RaisingRunner())
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=client,
+            config=config,
+            schema_preflight=SchemaPreflightRunner(FakeSchemaBackend()),
+        )
+        candidate = WriteCandidate(
+            object_name="待办",
+            layer="reminder",
+            semantic_fields=["summary", "owner", "priority", "customer"],
+            payload={
+                "summary": "跟进联合利华续费",
+                "owner": "ou_owner",
+                "priority": "高",
+                "customer": "联合利华",
+            },
+            operation="create",
+            target_object="todo",
+        )
+        result = writer.create(candidate)
+        self.assertEqual(result.preflight_status, "blocked")
+        self.assertEqual(result.guard_status, "blocked")
+        self.assertEqual(result.executed_operation, "blocked")
+        self.assertEqual(result.dedupe_decision, "no_write")
+        self.assertIn("todo_custom_field_missing", result.blocked_reasons)
+
+    def test_todo_writer_updates_semantic_duplicate_instead_of_creating(self) -> None:
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "owner": {
+                        "field_id": "members.assignee",
+                        "name": "负责人",
+                        "type": "user",
+                        "allowed_live_types": ["user"],
+                        "write_policy": "required_create",
+                        "valid_member_ids": ["ou_owner"],
+                    },
+                    "customer": {
+                        "field_id": "customer_guid",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                    "priority": {
+                        "field_id": "priority_guid",
+                        "name": "优先级",
+                        "type": "single_select",
+                        "options": ["高", "中", "低"],
+                        "allowed_live_types": ["single_select"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        responses = {
+            (
+                'task tasks get --params {"task_guid": "task_existing"}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=(
+                    '{"code":0,"data":{"task":{"guid":"task_existing","url":"https://applink.feishu.cn/client/todo/detail?guid=task_existing",'
+                    '"members":[{"id":"ou_owner","role":"assignee","type":"user"}]}}}'
+                ),
+                stderr="",
+            ),
+            (
+                'task tasks patch --params {"task_guid": "task_existing"} --data '
+                '{"task": {"summary": "跟进联合利华续费方案", '
+                '"due": {"timestamp": "1776614400000", "is_all_day": true}, '
+                '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华"}, '
+                '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "d7aff674-0ef8-6397-9108-fb260e21bde9"}]}, '
+                '"update_fields": ["summary", "due", "custom_fields"]}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"code":0,"data":{"task":{"guid":"task_existing","url":"https://applink.feishu.cn/client/todo/detail?guid=task_existing"}}}',
+                stderr="",
+            ),
+        }
+        client = LarkCliClient(runner=FakeRunner(responses))
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=client,
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "guid": "task_existing",
+                    "summary": "推进联合利华续费方案确认",
+                    "customer": "联合利华",
+                    "due_at": "2026-04-18",
+                }
+            ],
+        )
+        candidate = WriteCandidate(
+            object_name="待办",
+            layer="reminder",
+            semantic_fields=["summary", "owner", "customer", "priority"],
+            payload={
+                "summary": "跟进联合利华续费方案",
+                "owner": "ou_owner",
+                "customer": "联合利华",
+                "priority": "高",
+                "due_at": "2026-04-20",
+            },
+            operation="create",
+            target_object="todo",
+            match_basis={"customer": "联合利华", "time_window": "2026-04"},
+        )
+        result = writer.create(candidate)
+        self.assertTrue(result.attempted)
+        self.assertTrue(result.allowed)
+        self.assertEqual(result.dedupe_decision, "update_existing")
+        self.assertEqual(result.executed_operation, "update")
+        self.assertEqual(result.remote_object_id, "task_existing")
+        self.assertEqual(result.blocked_reasons, [])
+
+    def test_todo_writer_handles_chinese_punctuation_variant_as_duplicate(self) -> None:
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "owner": {
+                        "field_id": "members.assignee",
+                        "name": "负责人",
+                        "type": "user",
+                        "allowed_live_types": ["user"],
+                        "write_policy": "required_create",
+                        "valid_member_ids": ["ou_owner"],
+                    },
+                    "customer": {
+                        "field_id": "customer_guid",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                    "priority": {
+                        "field_id": "priority_guid",
+                        "name": "优先级",
+                        "type": "single_select",
+                        "options": ["高", "中", "低"],
+                        "allowed_live_types": ["single_select"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        responses = {
+            (
+                'task tasks get --params {"task_guid": "task_existing"}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=(
+                    '{"code":0,"data":{"task":{"guid":"task_existing","url":"https://applink.feishu.cn/client/todo/detail?guid=task_existing",'
+                    '"members":[{"id":"ou_owner","role":"assignee","type":"user"}]}}}'
+                ),
+                stderr="",
+            ),
+            (
+                'task tasks patch --params {"task_guid": "task_existing"} --data '
+                '{"task": {"summary": "跟进联合利华 AI 埋点产品介绍给触脉确认", '
+                '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华"}, '
+                '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "d7aff674-0ef8-6397-9108-fb260e21bde9"}]}, '
+                '"update_fields": ["summary", "custom_fields"]}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"code":0,"data":{"task":{"guid":"task_existing","url":"https://applink.feishu.cn/client/todo/detail?guid=task_existing"}}}',
+                stderr="",
+            ),
+        }
+        client = LarkCliClient(runner=FakeRunner(responses))
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=client,
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "guid": "task_existing",
+                    "summary": "联合利华-AI埋点产品介绍给触脉（王奇）",
+                    "customer": "联合利华",
+                    "due_at": "2026-04-18",
+                }
+            ],
+        )
+        candidate = WriteCandidate(
+            object_name="待办",
+            layer="reminder",
+            semantic_fields=["summary", "owner", "customer", "priority"],
+            payload={
+                "summary": "跟进联合利华 AI 埋点产品介绍给触脉确认",
+                "owner": "ou_owner",
+                "customer": "联合利华",
+                "priority": "高",
+            },
+            operation="create",
+            target_object="todo",
+            match_basis={"customer": "联合利华", "time_window": "2026-04"},
+        )
+        result = writer.create(candidate)
+        self.assertEqual(result.dedupe_decision, "update_existing")
+        self.assertEqual(result.executed_operation, "update")
+        self.assertEqual(result.remote_object_id, "task_existing")
+
+    def test_todo_writer_recommends_create_subtask_for_step_level_duplicate(self) -> None:
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "owner": {
+                        "field_id": "members.assignee",
+                        "name": "负责人",
+                        "type": "user",
+                        "allowed_live_types": ["user"],
+                        "write_policy": "required_create",
+                        "valid_member_ids": ["ou_owner"],
+                    },
+                    "customer": {
+                        "field_id": "customer_guid",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        class RaisingRunner:
+            def __call__(self, command, capture_output, text, check):
+                raise AssertionError("no write should be attempted when subtask is recommended")
+
+        client = LarkCliClient(runner=RaisingRunner())
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=client,
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "guid": "task_parent",
+                    "summary": "联合利华 活动 优化 方案",
+                    "customer": "联合利华",
+                    "due_at": "2026-04-20",
+                }
+            ],
+        )
+        candidate = WriteCandidate(
+            object_name="待办",
+            layer="reminder",
+            semantic_fields=["summary", "owner", "customer"],
+            payload={
+                "summary": "整理联合利华活动优化方案并发送会前资料",
+                "owner": "ou_owner",
+                "customer": "联合利华",
+            },
+            operation="create",
+            target_object="todo",
+            match_basis={"customer": "联合利华", "time_window": "2026-04"},
+        )
+        result = writer.create(candidate)
+        self.assertFalse(result.attempted)
+        self.assertEqual(result.dedupe_decision, "create_subtask")
+        self.assertEqual(result.executed_operation, "blocked")
+        self.assertIn("subtask_recommended", result.blocked_reasons)
+
+    def test_todo_writer_creates_subtask_when_explicitly_confirmed(self) -> None:
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "owner": {
+                        "field_id": "members.assignee",
+                        "name": "负责人",
+                        "type": "user",
+                        "allowed_live_types": ["user"],
+                        "write_policy": "required_create",
+                        "valid_member_ids": ["ou_owner"],
+                    },
+                    "customer": {
+                        "field_id": "customer_guid",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        responses = {
+            (
+                'task tasks create --data '
+                '{"summary": "整理联合利华活动优化方案并发送会前资料", '
+                '"tasklists": [{"tasklist_guid": "e50dda19-63e4-410a-a167-6813f3b3c86d"}], '
+                '"members": [{"id": "ou_owner", "role": "assignee", "type": "user"}], '
+                '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华"}], '
+                '"parent_task_guid": "task_parent"}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=(
+                    '{"code":0,"data":{"task":{"guid":"task_sub_1",'
+                    '"url":"https://applink.feishu.cn/client/todo/detail?guid=task_sub_1"}}}'
+                ),
+                stderr="",
+            )
+        }
+
+        client = LarkCliClient(runner=FakeRunner(responses))
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=client,
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "guid": "task_parent",
+                    "summary": "联合利华 活动 优化 方案",
+                    "customer": "联合利华",
+                    "due_at": "2026-04-20",
+                }
+            ],
+        )
+
+        candidate = WriteCandidate(
+            object_name="待办",
+            layer="reminder",
+            semantic_fields=["summary", "owner", "customer"],
+            payload={
+                "summary": "整理联合利华活动优化方案并发送会前资料",
+                "owner": "ou_owner",
+                "customer": "联合利华",
+            },
+            operation="create",
+            target_object="todo",
+            match_basis={"customer": "联合利华", "time_window": "2026-04"},
+            source_context={"confirm_create_subtask": True},
+        )
+        result = writer.create(candidate)
+
+        self.assertTrue(result.attempted)
+        self.assertTrue(result.allowed)
+        self.assertEqual(result.dedupe_decision, "create_subtask")
+        self.assertEqual(result.executed_operation, "create")
+        self.assertEqual(result.remote_object_id, "task_sub_1")
+
     def test_table_profiles_cover_runtime_and_expansion_tables(self) -> None:
         self.assertEqual(TABLE_PROFILES["客户主数据"].table_role, "snapshot")
         self.assertEqual(TABLE_PROFILES["客户联系记录"].table_role, "detail")
@@ -834,6 +1241,118 @@ class RuntimeSmokeTests(unittest.TestCase):
         self.assertIn("patch", result.request_payload)
         self.assertIn("member_add", result.request_payload)
         self.assertIn("member_remove", result.request_payload)
+
+    def test_todo_writer_updates_existing_task_when_duplicate_detected(self) -> None:
+        responses = {
+            (
+                'task tasks get --params {"task_guid": "task_existing"}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=(
+                    '{"code":0,"data":{"task":{"guid":"task_existing","url":"https://applink.feishu.cn/client/todo/detail?guid=task_existing",'
+                    '"members":[{"id":"ou_old","role":"assignee","type":"user"}]}}}'
+                ),
+                stderr="",
+            ),
+            (
+                'task tasks patch --params {"task_guid": "task_existing"} --data '
+                '{"task": {"summary": "跟进联合利华 AI 埋点产品介绍给触脉确认", "description": "补充新的会后上下文", '
+                '"due": {"timestamp": "1776096000000", "is_all_day": true}, '
+                '"custom_fields": [{"guid": "a7009aff-7d85-4378-82c9-1584873f469d", "text_value": "联合利华（UFS）"}, '
+                '{"guid": "f7587037-8ad1-443c-b350-f6600e0ccadd", "single_select_value": "d7aff674-0ef8-6397-9108-fb260e21bde9"}]}, '
+                '"update_fields": ["summary", "description", "due", "custom_fields"]}'
+            ): subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout='{"code":0,"data":{"task":{"guid":"task_existing","url":"https://applink.feishu.cn/client/todo/detail?guid=task_existing"}}}',
+                stderr="",
+            ),
+        }
+        client = LarkCliClient(runner=FakeRunner(responses))
+
+        class PassingTodoSchemaBackend:
+            def get_table_schema(self, object_name: str) -> dict[str, dict[str, object]] | None:
+                if object_name != "待办":
+                    return None
+                return {
+                    "summary": {
+                        "field_id": "summary",
+                        "name": "标题",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "required_create",
+                    },
+                    "description": {
+                        "field_id": "description",
+                        "name": "描述",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                    "due_at": {
+                        "field_id": "due",
+                        "name": "截止时间",
+                        "type": "datetime",
+                        "allowed_live_types": ["datetime"],
+                        "write_policy": "safe_update",
+                    },
+                    "customer": {
+                        "field_id": "a7009aff-7d85-4378-82c9-1584873f469d",
+                        "name": "客户",
+                        "type": "text",
+                        "allowed_live_types": ["text"],
+                        "write_policy": "safe_update",
+                    },
+                    "priority": {
+                        "field_id": "f7587037-8ad1-443c-b350-f6600e0ccadd",
+                        "name": "优先级",
+                        "type": "single_select",
+                        "options": ["高", "中", "低"],
+                        "allowed_live_types": ["single_select"],
+                        "write_policy": "safe_update",
+                    },
+                }
+
+        sources = RuntimeSourceLoader(REPO_ROOT).load()
+        config = LiveWorkbenchConfig.from_sources(sources)
+        writer = TodoWriter(
+            client=client,
+            config=config,
+            schema_preflight=SchemaPreflightRunner(PassingTodoSchemaBackend()),
+            existing_tasks=[
+                {
+                    "guid": "task_existing",
+                    "summary": "联合利华-AI埋点产品介绍给触脉（王奇）",
+                    "customer": "联合利华（UFS）",
+                    "due_at": "2026-04-14",
+                }
+            ],
+        )
+        candidate = WriteCandidate(
+            object_name="待办",
+            target_object="todo",
+            layer="reminder",
+            operation="create",
+            semantic_fields=["summary", "description", "due_at", "customer", "priority"],
+            payload={
+                "summary": "跟进联合利华 AI 埋点产品介绍给触脉确认",
+                "description": "补充新的会后上下文",
+                "due_at": "2026-04-14",
+                "customer": "联合利华（UFS）",
+                "priority": "高",
+            },
+            match_basis={"customer": "联合利华（UFS）", "time_window": "2026-04"},
+        )
+        result = writer.create(candidate)
+        self.assertTrue(result.attempted)
+        self.assertTrue(result.allowed)
+        self.assertEqual(result.executed_operation, "update")
+        self.assertEqual(result.dedupe_decision, "update_existing")
+        self.assertEqual(result.remote_object_id, "task_existing")
+        self.assertIn("patch", result.request_payload)
+        self.assertNotIn("member_add", result.request_payload)
+        self.assertNotIn("member_remove", result.request_payload)
 
     def test_capability_report_degrades_when_required_table_missing(self) -> None:
         responses = {

--- a/validation-reports/2026-04-12-unified-todo-writer-live-validation.md
+++ b/validation-reports/2026-04-12-unified-todo-writer-live-validation.md
@@ -1,0 +1,146 @@
+# Unified Todo Writer Live Validation
+
+日期：2026-04-12
+
+## 目标
+
+验证 unified Todo writer 在真实 Feishu 环境下，是否已能稳定产出这 3 类可审计结果：
+
+- `blocked`
+- `duplicate`
+- `create`
+
+## 执行环境
+
+- runtime diagnostic: `base_access=available`、`docs_access=available`、`task_access=available`
+- tasklist: `神策`
+- writer: `runtime/todo_writer.py`
+
+## 样本结果
+
+### 1. blocked
+
+样本：
+
+- candidate 不带 owner
+- customer: `联合利华（UFS）`
+
+结果：
+
+- `attempted=false`
+- `allowed=false`
+- `preflight_status=blocked`
+- `guard_status=blocked`
+- `dedupe_decision=no_write`
+- `executed_operation=blocked`
+- `blocked_reasons=["owner_unresolved"]`
+
+结论：
+
+- 符合预期
+- 没有真实写入
+
+### 2. duplicate
+
+样本：
+
+- 基于真实现有任务 `ea0d6e95-4ae0-4dff-92e0-b6e43bc8b414`
+- 现有任务标题：`联合利华-AI埋点产品介绍给触脉（王奇）`
+- 候选标题：`跟进联合利华 AI 埋点产品介绍给触脉确认`
+
+第一轮结果：
+
+- 错误创建了新任务
+- 已立即清理
+
+根因：
+
+- dedupe tokenizer 对中文连续文本、连字符和括号拆分不足
+
+修正后第二轮结果：
+
+- `attempted=false`
+- `allowed=false`
+- `preflight_status=safe`
+- `guard_status=allowed`
+- `dedupe_decision=update_existing`
+- `executed_operation=blocked`
+- `blocked_reasons=["semantic_duplicate_detected"]`
+- `remote_object_id="ea0d6e95-4ae0-4dff-92e0-b6e43bc8b414"`
+
+结论：
+
+- 修正后符合预期
+- 没有重复写入
+
+### 2.1 duplicate -> update auto patch
+
+样本：
+
+- 先创建 1 条带 `VALIDATION` 标记的 seed task
+- 再提交一个近重复 candidate
+- 由 unified Todo writer 自动命中 duplicate 并走 `update()` 路径
+
+结果：
+
+- `attempted=true`
+- `allowed=true`
+- `dedupe_decision=update_existing`
+- `executed_operation=update`
+- `remote_object_id` 等于 seed task guid
+
+实际确认：
+
+- summary 已更新为新标题
+- description 已更新为新说明
+- due 已更新为新时间
+
+清理：
+
+- seed task 已在验证后删除
+
+结论：
+
+- duplicate -> update 的自动 patch 路径已在真实 Feishu 环境验证通过
+
+### 3. create
+
+样本：
+
+- 标题：`VALIDATION｜unified Todo writer create sample｜2026-04-12B`
+- owner: `ou_8855be9f7b67cf309ff7e2fb800dcbb5`
+- customer: `联合利华（UFS）`
+- priority: `中`
+
+结果：
+
+- `attempted=true`
+- `allowed=true`
+- `preflight_status=safe`
+- `guard_status=allowed`
+- `dedupe_decision=create_new`
+- `executed_operation=create`
+- `remote_object_id="eadb178b-6cce-487e-b8d9-16f75c67f277"`
+
+清理：
+
+- 已在验证后调用真实 delete 清理该任务
+
+结论：
+
+- 符合预期
+
+## 总结
+
+当前 unified Todo writer 已在真实 Feishu 环境下跑通：
+
+- blocked
+- duplicate
+- create
+- duplicate -> update
+
+当前仍需后续继续补强的点：
+
+- dedupe 仍是第一版规则，当前只证明最小闭环成立
+- duplicate -> update 已打通自动 patch
+- create_subtask 当前为默认 recommendation-only，需显式确认（`confirm_create_subtask=true`）才执行真实写入


### PR DESCRIPTION
## Summary
- 强化统一 Todo 写回能力，完善语义去重与子任务建议/确认执行路径，提升写回稳定性与可审计性。
- 增加 meeting bridge 的相关会议纪要候选命中与排序能力，提升会议场景上下文恢复质量。
- 重写产品文档与验证文档，统一业务视角表述并同步最新验证证据。

### Commits
- feat: stabilize todo writer dedupe and optional subtask execution
- feat: add meeting-note candidate ranking in meeting bridge
- docs: refresh product docs and validation records

## Test Coverage
- 执行命令：`python3 -m unittest tests.test_runtime_smoke tests.test_meeting_output_bridge tests.test_eval_runner tests.test_validation_assets`
- 结果：59 tests, 0 failures

## Pre-Landing Review
- 已完成实现级检查与回归验证，当前未发现阻断发布问题。

## Verification Results
- runtime 诊断：base/docs/task 可用
- 全量回归：通过
- create_subtask live 验证：显式确认后可创建，且验证任务已清理

## Test plan
- [x] 全量回归通过（59 tests）
- [x] meeting bridge 场景验证通过
- [x] unified todo writer 关键路径验证通过
